### PR TITLE
Rudimental session management. discord.kak refactor.

### DIFF
--- a/rc/discord.kak
+++ b/rc/discord.kak
@@ -1,21 +1,29 @@
-declare-option -hidden str discord_fifo ""
+declare-option -hidden str discord_fifo
 
-hook global KakBegin .* %{
-	evaluate-commands %sh{
-		if [ -z $TMPDIR ]; then TMPDIR=/tmp; fi
-		mkfifo "$TMPDIR/kakoune/discord"
-		echo "set-option global discord_fifo $TMPDIR/kakoune/discord"
-	}
-	nop %sh{ { kakoune-discord "$kak_opt_discord_fifo"; } > /dev/null 2>&1 < /dev/null & }
-}
+define-command -hidden discord-fifo-send -params 1 %{ nop %sh{
+    { echo "$1" > "$kak_opt_discord_fifo"; } >/dev/null 2>&1 </dev/null &
+} }
 
-hook global WinDisplay .* %{
-	nop %sh{ { echo $kak_reg_percent > "$kak_opt_discord_fifo"; } > /dev/null 2>&1 < /dev/null & }
-}
+define-command discord-presence-enable \
+    -docstring "Enable Discord rich presence for this kakoune session" %{
+    evaluate-commands %sh{
+        fifo=${TMPDIR:-/tmp}/kakoune/discord
+        echo "set-option global discord_fifo $fifo"
+        if [ ! -p "$fifo" ]; then
+            mkfifo "$fifo"
+            kakoune-discord "$fifo" >/dev/null 2>&1 </dev/null &
+        fi
+    }
+    discord-fifo-send '+'
 
-hook global KakEnd .* %{
-	nop %sh{
-		echo 'exit' > "$kak_opt_discord_fifo"
-		rm "$kak_opt_discord_fifo"
-	}
+    hook global -group discord FocusIn .* %{ discord-fifo-send %reg{%} }
+    hook global -group discord WinDisplay .* %{ discord-fifo-send %reg{%} }
+    hook global -group discord KakEnd .* %{ discord-fifo-send '-' }
+
+    define-command discord-presence-disable \
+        -docstring "Disable Discord rich presence for this kakoune session" %{
+        discord-fifo-send '-'
+        unset-option global discord_fifo
+        remove-hooks global discord
+    }
 }


### PR DESCRIPTION
Basically, now daemon keeps count of connected clients and only terminates when no clients are connected and cleanups the fifo (meaning, now there is only one `kakoune-discord` process per all kakoune sessions). Since no IPC protocol is defined, i tried to keep collisions with filenames minimal, by using `+` as client connection and `-` as disconnect.

`discord.kak` also now only activates by invoking `discord-presence-enable`, which activates necessary hooks and adds command for deactivation. And helper function `discord-fifo-send` makes sending commands easier.

Also, i don't know rust, so if something looks non-idiomatic or plain bad, please point it out.